### PR TITLE
feat: add start of folder hierarchie structure

### DIFF
--- a/src/Utils/AssetManager.cpp
+++ b/src/Utils/AssetManager.cpp
@@ -9,14 +9,27 @@ AssetManager::AssetManager(const char* path)
     for(const auto &entry : fs::directory_iterator(path))
     {
         std::string extension = entry.path().extension();
-        if(extension == ".jpeg" || extension == ".png")
-        {
-            File file;
-            file.fileName = entry.path().filename();
-            file.filePath = entry.path();
-            file.extension = entry.path().extension();
-            
-            AssetManager::m_filePaths.push_back(file);
-        }
+        std::string entryPath = entry.path();
+        std::string type = GetFileType(entryPath);
+        
+        Asset asset;
+        asset.name = entry.path().filename();
+        asset.path = entry.path();
+        asset.extension = entry.path().extension();
+        asset.type = type;
+        
+        AssetManager::m_assets.push_back(asset);
+        
+    }
+}
+
+std::string AssetManager::GetFileType(std::string& path)
+{
+    fs::file_status status = fs::status(path);
+    switch(status.type())
+    {
+        case fs::file_type::directory: return "dir";
+            break;
+        default: return "file";
     }
 }

--- a/src/Utils/AssetManager.hpp
+++ b/src/Utils/AssetManager.hpp
@@ -1,17 +1,21 @@
 #include <iostream>
 #include <vector>
 
-struct File
+namespace fs = std::__fs::filesystem;
+
+struct Asset
 {
-    std::string fileName;
-    std::string filePath;
+    std::string name;
+    std::string path;
     std::string extension;
+    std::string type;
 };
 
 class AssetManager
 {
 public:
     AssetManager(const char* path);
+    std::string GetFileType(std::string& path);
 public:
-    std::vector<File> m_filePaths;
+    std::vector<Asset> m_assets;
 };

--- a/src/imgui.ini
+++ b/src/imgui.ini
@@ -9,17 +9,17 @@ Size=298,197
 Collapsed=0
 
 [Window][Sidebar]
-Pos=0,1
+Pos=2,-1
 Size=216,254
 Collapsed=0
 
 [Window][Textures]
-Pos=0,250
-Size=222,163
+Pos=5,253
+Size=398,290
 Collapsed=0
 
 [Window][OpenGL Texture Text]
-Pos=489,129
-Size=581,560
+Pos=3,758
+Size=581,139
 Collapsed=0
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -93,7 +93,6 @@ int main() {
 		
 		renderer.DrawCube();
 		
-		
 		glm::mat4 viewMatrix2 = GetTranslationMatrix(glm::vec3(gameVariables.xPos + 1.0, gameVariables.yPos, gameVariables.zPos));
 		shader.SetMatrix4fUniform("viewMatrix", viewMatrix2);
 		renderer.DrawCube();
@@ -118,22 +117,29 @@ int main() {
 		ImGui::BeginChild("Scrolling");
 		ImGui::Text("Texture");
 		
-		ImGui::Begin("OpenGL Texture Text");
-		ImGui::ImageButton((void*)(intptr_t)folderTexture.m_textureId, ImVec2(50.0f, 50.0f), ImVec2(0.0f, 0.0f), ImVec2(1.0, 1.0f), 10);
-		ImGui::Text("Assets");
-//		ImGui::Image((void*)(intptr_t)folderTexture.m_textureId, ImVec2(50, 50));
-		ImGui::End();
-
-		for (int i = 0; i < assets.m_filePaths.size(); i++)
+		for (int i = 0; i < assets.m_assets.size(); i++)
 		{
-			std::string fileExtension = assets.m_filePaths[i].extension;
-			std::string filePath = assets.m_filePaths[i].filePath;
-			std::string fileName = assets.m_filePaths[i].fileName;
-			if(ImGui::Button(fileName.c_str()))
+			std::string extension = assets.m_assets[i].extension;
+			std::string path = assets.m_assets[i].path;
+			std::string name = assets.m_assets[i].name;
+			std::string type = assets.m_assets[i].type;
+			
+			if(type == "dir")
 			{
-				texture.Load(filePath, fileExtension);
-				texture.Bind(GL_TEXTURE0);
+				if(ImGui::ImageButton((void*)(intptr_t)folderTexture.m_textureId, ImVec2(50.0f, 50.0f), ImVec2(0.0f, 0.0f), ImVec2(1.0, 1.0f), 10))
+				{
+					assets = AssetManager(path.c_str());
+				}
+				ImGui::Text("%s", name.c_str());
+			} else
+			{
+				if(ImGui::Button(name.c_str()))
+				{
+					texture.Load(path, extension);
+					texture.Bind(GL_TEXTURE0);
+				}
 			}
+			
 		};
 		ImGui::EndChild();
 		ImGui::End();


### PR DESCRIPTION
Added a file type to the asset manager from which I can determine if the current file is a file or a directory, and render a folder image whenever it's a directory where I can move into. 