### PR TITLE
feat: traverse assets through path traversal

### DIFF
--- a/src/Utils/AssetManager.cpp
+++ b/src/Utils/AssetManager.cpp
@@ -6,7 +6,17 @@ namespace fs = std::__fs::filesystem;
 
 AssetManager::AssetManager(const char* path)
 {
-    for(const auto &entry : fs::directory_iterator(path))
+    AssetManager::m_rootPath = path;
+    LoadDir(path);
+    AddVisitedPath(path);
+}
+
+void AssetManager::LoadDir(const std::string path)
+{
+    Reset();
+    AssetManager::m_currentPath = path;
+    
+    for(const auto& entry : fs::directory_iterator(path))
     {
         std::string extension = entry.path().extension();
         std::string entryPath = entry.path();
@@ -21,6 +31,28 @@ AssetManager::AssetManager(const char* path)
         AssetManager::m_assets.push_back(asset);
         
     }
+}
+
+void AssetManager::AddVisitedPath(const std::string path)
+{
+    fs::path fsPath = fs::path(path);
+    
+    Path dirPath;
+    dirPath.stem = fsPath.stem();
+    dirPath.path = path;
+    path == AssetManager::m_rootPath ? dirPath.isRootPath = true : dirPath.isRootPath = false;
+    
+    AssetManager::m_visitedPaths.push_back(dirPath);
+}
+
+void AssetManager::DeleteLastVisitedPath()
+{
+    AssetManager::m_visitedPaths.pop_back();
+}
+
+void AssetManager::Reset()
+{
+    AssetManager::m_assets.clear();
 }
 
 std::string AssetManager::GetFileType(std::string& path)

--- a/src/Utils/AssetManager.hpp
+++ b/src/Utils/AssetManager.hpp
@@ -11,11 +11,25 @@ struct Asset
     std::string type;
 };
 
+struct Path
+{
+    std::string stem;
+    std::string path;
+    bool isRootPath;
+};
+
 class AssetManager
 {
 public:
     AssetManager(const char* path);
     std::string GetFileType(std::string& path);
+    void LoadDir(const std::string path);
+    void AddVisitedPath(const std::string path);
+    void DeleteLastVisitedPath();
+    void Reset();
 public:
+    std::string m_rootPath;
+    std::string m_currentPath;
     std::vector<Asset> m_assets;
+    std::vector<Path> m_visitedPaths;
 };

--- a/src/imgui.ini
+++ b/src/imgui.ini
@@ -9,7 +9,7 @@ Size=298,197
 Collapsed=0
 
 [Window][Sidebar]
-Pos=0,2
+Pos=1,2
 Size=216,254
 Collapsed=0
 
@@ -24,7 +24,7 @@ Size=581,139
 Collapsed=0
 
 [Window][Assets]
-Pos=2,688
+Pos=0,688
 Size=1198,210
 Collapsed=0
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -86,7 +86,7 @@ int main() {
 		glm::mat4 modelMatrix = GetRotationMatrix(gameVariables.rotationDegrees, glm::vec3((float)gameVariables.rotateX, (float)gameVariables.rotateY, (float)gameVariables.rotateZ));
 		shader.SetMatrix4fUniform("modelMatrix", modelMatrix);
 		
-		glm::mat4 viewMatrix = GetTranslationMatrix(glm::vec3(gameVariables.xPos - 1.0, gameVariables.yPos, gameVariables.zPos));
+		glm::mat4 viewMatrix = GetTranslationMatrix(glm::vec3(gameVariables.xPos, gameVariables.yPos, gameVariables.zPos));
 		shader.SetMatrix4fUniform("viewMatrix", viewMatrix);
 		
 		glm::mat4 projectionMatrix = GetProjectionMatrix(45.0f, gameVariables.windowWidth, gameVariables.windowHeight, 0.1f, 100.0f);
@@ -96,10 +96,6 @@ int main() {
 		
 		renderer.DrawCube();
 		
-		glm::mat4 viewMatrix2 = GetTranslationMatrix(glm::vec3(gameVariables.xPos + 1.0, gameVariables.yPos, gameVariables.zPos));
-		shader.SetMatrix4fUniform("viewMatrix", viewMatrix2);
-		renderer.DrawCube();
-	
 		ImGui::Begin("Sidebar");
 		ImGui::Text("Rotation Degrees");
 		ImGui::SliderFloat("", &gameVariables.rotationDegrees, 0.0f, 360.0f);
@@ -116,8 +112,22 @@ int main() {
 		
 		ImGui::End();
 		
-		// TODO:: Create a dynamic vector array, inside AssetManager class that keeps track of the folder hierachie clicked. + Add a back button to traverse through the assets
 		ImGui::Begin("Assets");
+		for(int i = 0; i < assets.m_visitedPaths.size(); i++)
+		{
+			std::string& dirPath = assets.m_visitedPaths[i].path;
+			std::string& dirName = assets.m_visitedPaths[i].stem;
+			
+			ImGui::SameLine();
+			if(ImGui::Button(dirName.c_str()))
+			{
+				if(dirPath != assets.m_currentPath)
+					assets.DeleteLastVisitedPath();
+				
+				assets.LoadDir(dirPath.c_str());
+			}
+		}
+
 		for (int i = 0; i < assets.m_assets.size(); i++)
 		{
 			std::string extension = assets.m_assets[i].extension;
@@ -131,7 +141,8 @@ int main() {
 			{
 				if(ImGui::ImageButtonWithText((void*)(intptr_t)folderTexture.m_textureId, name.c_str(), ImVec2(50.0f, 50.0f)))
 				{
-					assets = AssetManager(path.c_str());
+					assets.LoadDir(path.c_str());
+					assets.AddVisitedPath(path);
 				}
 			} else
 			{


### PR DESCRIPTION
Added a way to traverse through folders and keeping track of the folder hierarchie. 
Buttons are added for every folder hierarchie. And wheen that button is clicked. The user will load the directory related to that button dir. 