### PR TITLE
feat: add start of adding lights as entities

### DIFF
--- a/src/Entity/Light.cpp
+++ b/src/Entity/Light.cpp
@@ -1,0 +1,8 @@
+//
+//  Light.cpp
+//  Luminosity
+//
+//  Created by Mitchel Wijt on 06/11/2021.
+//
+
+//#include "Light.hpp"

--- a/src/Entity/Light.hpp
+++ b/src/Entity/Light.hpp
@@ -4,10 +4,9 @@
 #include "../Utils/Math.hpp"
 #include "../Renderer/RenderApi.hpp"
 #include "../Shaders/Shader.hpp"
-#include "../Textures/Texture.hpp"
 
 
-std::vector<float> vertices {
+std::vector<float> lightVertices {
     -0.5f, -0.5f, -0.5f,    0.0f, 0.0f,     0.0f, 0.0f, -1.0f,
     0.5f, -0.5f, -0.5f,     1.0f, 0.0f,     0.0f, 0.0f, -1.0f,
     0.5f,  0.5f, -0.5f,     1.0f, 1.0f,     0.0f, 0.0f, -1.0f,
@@ -51,63 +50,42 @@ std::vector<float> vertices {
     -0.5f,  0.5f, -0.5f,    0.0f, 1.0f,     0.0f, 1.0f, 0.0f
 };
 
-class Cube : public Entity {
+class Light : public Entity {
 public:
-    Cube()
+    Light()
     {
-        renderer.Create(vertices);
+        renderer.Create(lightVertices);
         
-        Cube::transform = glm::vec3(0.0f, 0.0f, -8.0f);
-        Cube::rotateX = true;
-        Cube::rotateY = false;
-        Cube::rotateZ = false;
-        Cube::scale = glm::vec3(1.0f, 1.0f, 1.0f);
-        Cube::color = glm::vec3(1.0f, 1.0f, 1.0f);
-        Cube::texturePath = "../assets/brickwall.jpeg";
-        
-        LoadTexture();
+        Light::transform = glm::vec3(0.0f, 0.0f, -8.0f);
+        Light::rotateX = true;
+        Light::rotateY = false;
+        Light::rotateZ = false;
+        Light::scale = glm::vec3(1.0f, 1.0f, 1.0f);
+        Light::color = glm::vec3(1.0f, 1.0f, 1.0f);
     }
     
     void Draw()
     {
         shader.Use();
-        BindTexture();
         SetMVPMatrix();
         renderer.Draw();
-    }
-    
-    void LoadTexture()
-    {
-        texture.Load(texturePath, ".jpeg");
-        shader.Set1iUniform("ourTexture", 0);
-
-    }
-    
-    void BindTexture()
-    {
-        texture.Bind(GL_TEXTURE0);
     }
     
 private:
     void SetMVPMatrix()
     {
-        shader.Set3fUniform("lightColor", glm::vec3(1.0f, 1.0f, 1.0f));
-        shader.Set3fUniform("lightPos", glm::vec3(5.0f, 3.0f, -4.0f));
-        shader.Set3fUniform("ourColor", Cube::color);
-        
-        glm::mat4 scaleMatrix = GetScaleMatrix(Cube::scale);
-        glm::mat4 rotationMatrix = GetRotationMatrix(Cube::rotationDegrees, glm::vec3((float)rotateX, (float)rotateY, (float)rotateZ));
+        glm::mat4 scaleMatrix = GetScaleMatrix(Light::scale);
+        glm::mat4 rotationMatrix = GetRotationMatrix(Light::rotationDegrees, glm::vec3((float)rotateX, (float)rotateY, (float)rotateZ));
         glm::mat4 modelMatrix =  rotationMatrix * scaleMatrix;
         shader.SetMatrix4fUniform("modelMatrix", modelMatrix);
         
-        glm::mat4 viewMatrix = GetTranslationMatrix(Cube::transform);
+        glm::mat4 viewMatrix = GetTranslationMatrix(Light::transform);
         shader.SetMatrix4fUniform("viewMatrix", viewMatrix);
 
         glm::mat4 projectionMatrix = GetProjectionMatrix(45.0f, 1200, 900, 0.1f, 100.0f);
         shader.SetMatrix4fUniform("projectionMatrix", projectionMatrix);
     }
 public:
-    Texture2D texture = Texture2D();
     RenderApi renderer = RenderApi();
-    Shaders shader = Shaders("Shaders/Object/VertexShader.glsl", "Shaders/Object/FragmentShader.glsl");
+    Shaders shader = Shaders("Shaders/Lighting/VertexShader.glsl", "Shaders/Lighting/FragmentShader.glsl");
 };

--- a/src/Shaders/Object/FragmentShader.glsl
+++ b/src/Shaders/Object/FragmentShader.glsl
@@ -1,3 +1,4 @@
+
 #version 330 core
 
 in vec2 texCoord;
@@ -8,8 +9,20 @@ out vec4 FragColor;
 
 uniform sampler2D ourTexture;
 uniform vec3 ourColor;
+uniform vec3 lightColor;
+uniform vec3 lightPos;
 
 void main()
 {
-    FragColor = texture(ourTexture, texCoord) * vec4(ourColor, 1.0f);
+    vec3 norm = normalize(normal);
+    vec3 lightDir = normalize(lightPos - fragPos);
+    
+    float diff = max(dot(norm, lightDir), 0.0);
+    vec3 diffuse = diff * lightColor;
+    
+    float ambientStrength = 0.1;
+    vec3 ambient = ambientStrength * lightColor;
+    
+    vec3 result = (ambient + diffuse) * ourColor;
+    FragColor = texture(ourTexture, texCoord) * vec4(result, 1.0f);
 }

--- a/src/imgui.ini
+++ b/src/imgui.ini
@@ -9,7 +9,7 @@ Size=298,197
 Collapsed=0
 
 [Window][Sidebar]
-Pos=3,2
+Pos=10,4
 Size=216,655
 Collapsed=0
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,7 @@
 #include "Textures/Texture.hpp"
 #include "Renderer/RenderApi.hpp"
 #include "Entity/Cube.hpp"
+#include "Entity/Light.hpp"
 
 #include "../editor/panels/ContentBrowserPanel.hpp"
 
@@ -13,7 +14,9 @@
 #include "../libs/imgui/imgui_impl_opengl3.h"
 
 std::vector<Cube> cubes;
+std::vector<Light> lights;
 bool createEntity = false;
+bool createLight = false;
 
 void CreateEntity()
 {
@@ -21,6 +24,14 @@ void CreateEntity()
 	cubes.push_back(cube);
 	
 	createEntity = false;
+}
+
+void CreateLight()
+{
+	Light light = Light();
+	lights.push_back(light);
+	
+	createLight = false;
 }
 
 //void window_size_callback(GLFWwindow* window, int width, int height)
@@ -54,17 +65,8 @@ int main() {
 		if(createEntity)
 			CreateEntity();
 		
-		
-//		float lightX = gameVariables.lightRadius * sin(glfwGetTime());
-//		float lightY = gameVariables.yPos;
-//		float lightZ = gameVariables.zPos + cos(glfwGetTime());
-//
-//		glm::vec3 lightPos = glm::vec3(lightX, lightY, lightZ);
-//
-//		float lightX2 = 0.0f;
-//		float lightY2 = cos(glfwGetTime());
-//		float lightZ2 = gameVariables.zPos + (gameVariables.lightRadius * sin(glfwGetTime()));
-//		glm::vec3 lightPos2 = glm::vec3(lightX2, lightY2, lightZ2);
+		if(createLight)
+			CreateLight();
 		
 		if(cubes.size() > 0) {
 			for(int i = 0; i < cubes.size(); i++)
@@ -72,36 +74,36 @@ int main() {
 				cubes[i].Draw();
 			}
 		}
-				
-		//Light 1
-//		lightingShader.Use();
-//
-//		glm::mat4 modelMatrixLight = GetScaleMatrix(glm::vec3(0.2, 0.2, 0.2));
-//		lightingShader.SetMatrix4fUniform("modelMatrix", modelMatrixLight);
-//
-//		glm::mat4 viewMatrixLight = GetTranslationMatrix(lightPos);
-//		lightingShader.SetMatrix4fUniform("viewMatrix", viewMatrixLight);
-//
-//		glm::mat4 projectionMatrixLight = GetProjectionMatrix(45.0f, gameVariables.windowWidth, gameVariables.windowHeight, 0.1f, 100.0f);
-//		lightingShader.SetMatrix4fUniform("projectionMatrix", projectionMatrixLight);
-//
-//		lightSourceRenderer.DrawCube();
 		
-		//Light 2
-//		lightingShader.Use();
-//
-//		glm::mat4 viewMatrixLight2 = GetTranslationMatrix(lightPos2);
-//		lightingShader.SetMatrix4fUniform("viewMatrix", viewMatrixLight2);
-//
-//		lightSourceRenderer.DrawCube();
-		
+		if(lights.size() > 0) {
+			for(int i = 0; i < lights.size(); i++)
+			{
+				float lightX = 2.0f * sin(glfwGetTime());
+				float lightY = lights[i].transform.y;
+				float lightZ = -8.0f + cos(glfwGetTime());
+
+				lights[i].transform = glm::vec3(lightX, lightY, lightZ);
+				lights[i].Draw();
+			}
+		}
+						
 		//UI
 		ImGui::Begin("Sidebar");
-				
-		if(ImGui::Button("Create Entity")){
-			createEntity = true;
-		}
 		
+		if(ImGui::BeginMenu("Create"))
+		{
+			if(ImGui::MenuItem("Entity"))
+			{
+				createEntity = true;
+			}
+			if(ImGui::MenuItem("Light"))
+			{
+				createLight = true;
+			}
+			
+			ImGui::EndMenu();
+		}
+				
 		if(cubes.size() > 0) {
 			for(int i = 0; i < cubes.size(); i++)
 			{
@@ -116,6 +118,24 @@ int main() {
 				ImGui::Text("Scale");
 				ImGui::InputFloat3("Scaling", (float*)&cubes[i].scale);
 				ImGui::ColorEdit3("Color", (float*)&cubes[i].color);
+				ImGui::PopID();
+			}
+		}
+		
+		if(lights.size() > 0) {
+			for(int i = 0; i < lights.size(); i++)
+			{
+				ImGui::PushID(i + 1);
+				ImGui::Text("Cube %i", i);
+				ImGui::SliderFloat("Rotation Degrees", &lights[i].rotationDegrees, 0.0f, 360.0f);
+				ImGui::Text("Rotation Axis");
+				ImGui::Checkbox("X", &lights[i].rotateX);
+				ImGui::Checkbox("Y", &lights[i].rotateY);
+				ImGui::Checkbox("Z", &lights[i].rotateZ);
+				ImGui::SliderFloat3("Transform", (float*)&lights[i].transform, -10.0f, 10.0f);
+				ImGui::Text("Scale");
+				ImGui::InputFloat3("Scaling", (float*)&lights[i].scale);
+				ImGui::ColorEdit3("Color", (float*)&lights[i].color);
 				ImGui::PopID();
 			}
 		}


### PR DESCRIPTION
Added the start of adding lights as entities. 

TODO: 
- Make sure cube and lights are just entities and not 2 separate things
- Loosely couple the shader from the entity as opposed to tightly couple them. (we need to be able to set uniforms in a more generic way)