### PR TITLE
feat: add separate textures for entities

### DIFF
--- a/editor/panels/ContentBrowserPanel.cpp
+++ b/editor/panels/ContentBrowserPanel.cpp
@@ -14,11 +14,13 @@ AssetManager g_assets = AssetManager(g_assetPath);
 ContentBrowserPanel::ContentBrowserPanel()
 {
     Texture2D folderIcon = Texture2D();
-    folderIcon.Load("../editor/assets/folder.png", ".png");
+    TextureData texDataFolder = folderIcon.Create("../editor/assets/folder.png", ".png");
+    folderIcon.Load(texDataFolder);
     m_folderIcon = folderIcon.m_textureId;
     
     Texture2D fileIcon = Texture2D();
-    fileIcon.Load("../editor/assets/file.png", ".png");
+    TextureData texDataFile = fileIcon.Create("../editor/assets/file.png", ".png");
+    fileIcon.Load(texDataFile);
     m_fileIcon = fileIcon.m_textureId;
 }
 
@@ -65,15 +67,9 @@ void ContentBrowserPanel::OnImGuiRender()
             ImGui::ImageButtonWithText((void*)(intptr_t)m_fileIcon, name.c_str(), ImVec2(50.0f, 50.0f));
             if (ImGui::BeginDragDropSource())
             {
-                ImGui::SetDragDropPayload("CONTENT_BROWSER_ITEM", path.c_str(), path.length());
+                ImGui::SetDragDropPayload("CONTENT_BROWSER_ITEM", path.c_str(), sizeof(path));
                 ImGui::EndDragDropSource();
             }
-//            if(ImGui::ImageButtonWithText((void*)(intptr_t)m_fileIcon, name.c_str(), ImVec2(50.0f, 50.0f)))
-//            {
-//                meshTexture->Load(path, extension);
-//                meshTexture->Bind(GL_TEXTURE0);
-//            }
-            
         }
         
         ImGui::PopID();

--- a/src/Entity/Entity.hpp
+++ b/src/Entity/Entity.hpp
@@ -73,7 +73,7 @@ public:
     
     void SetTexture(Shaders shader)
     {
-        texture.Load(m_texturePath, ".jpeg");
+        texture.Load(textureData);
         shader.Set1iUniform("ourTexture", 0);
         texture.Bind(GL_TEXTURE0);
     }
@@ -125,5 +125,6 @@ public:
     bool m_orbitY = false;
     std::string m_texturePath;
     std::vector<float> m_vertices;
+    TextureData textureData;
     Texture2D texture = Texture2D();
 };

--- a/src/Shaders/Object/FragmentShader.glsl
+++ b/src/Shaders/Object/FragmentShader.glsl
@@ -30,7 +30,7 @@ void main()
         result += (CalcDirLight(dirLights[i + 1], norm, fragPos) * ourColor);
     }
     
-    FragColor = vec4(result, 1.0f);
+    FragColor = texture(ourTexture, texCoord) + vec4(result, 1.0f);
     
 }
 

--- a/src/Textures/Texture.cpp
+++ b/src/Textures/Texture.cpp
@@ -23,7 +23,7 @@ Texture2D::~Texture2D() {
     stbi_image_free(Texture2D::m_data);
 }
 
-void Texture2D::Load(const std::string& path, const std::string& extension)
+TextureData Texture2D::Create(const std::string& path, const std::string& extension)
 {
     int width;
     int height;
@@ -31,17 +31,26 @@ void Texture2D::Load(const std::string& path, const std::string& extension)
     
     unsigned int colorType = extension == ".jpeg" || extension == ".jpg" ? GL_RGB : GL_RGBA;
 
-//    stbi_set_flip_vertically_on_load(true);  
+//    stbi_set_flip_vertically_on_load(true);
     unsigned char* data = stbi_load(path.c_str(), &width, &height, &nrChannels, 0);
     
     if(!data)
         std::cout << "Failed to load texture at path: " << path << std::endl;
     
-    Texture2D::m_data = data;
-    Texture2D::m_width = width;
-    Texture2D::m_height = height;
+    TextureData textureData;
+    textureData.width = width;
+    textureData.height = height;
+    textureData.colorType = colorType;
+    textureData.data = data;
     
-    glTexImage2D(GL_TEXTURE_2D, 0, colorType, width, height, 0, colorType, GL_UNSIGNED_BYTE, data);
+    Texture2D::m_data = data;
+    
+    return textureData;
+}
+
+void Texture2D::Load(TextureData textureData)
+{    
+    glTexImage2D(GL_TEXTURE_2D, 0, textureData.colorType, textureData.width, textureData.height, 0, textureData.colorType, GL_UNSIGNED_BYTE, textureData.data);
     glGenerateMipmap(GL_TEXTURE_2D);
 }
 

--- a/src/Textures/Texture.hpp
+++ b/src/Textures/Texture.hpp
@@ -1,17 +1,27 @@
 #pragma once
 #include <iostream>
 
+
+struct TextureData {
+    unsigned int width;
+    unsigned int height;
+    unsigned int colorType;
+    unsigned char* data;
+};
+
 class Texture2D
 {
 public:
     Texture2D();
     ~Texture2D();
-    void Load(const std::string& path, const std::string& extension);
+    TextureData Create(const std::string& path, const std::string& extension);
+    void Load(TextureData textureData);
     void Bind(unsigned int unit);
     void Unbind();
     
     
 public:
+    unsigned int m_colorType;
     unsigned int m_width;
     unsigned int m_height;
     unsigned int m_textureId;

--- a/src/imgui.ini
+++ b/src/imgui.ini
@@ -24,7 +24,7 @@ Size=581,139
 Collapsed=0
 
 [Window][Assets]
-Pos=-1,684
+Pos=5,685
 Size=1198,210
 Collapsed=0
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,7 +46,7 @@ int main() {
 	Shaders lightShader = Shaders("Shaders/Lighting/VertexShader.glsl", "Shaders/Lighting/FragmentShader.glsl");
 
 	RenderApi renderer = RenderApi();
-					
+						
     while(!glfwWindowShouldClose(window)) {
 		processInput(window);
 		
@@ -95,6 +95,9 @@ int main() {
 				} else {
 					entityShader.Use();
 					entities[i].SetMVPMatrix(entityShader);
+					entities[i].SetTexture(entityShader);
+					
+					
 					renderer.Draw();
 				}
 				
@@ -150,9 +153,11 @@ int main() {
 					{
 						if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("CONTENT_BROWSER_ITEM"))
 						{
-							std::string path = *(std::string*)payload->Data;
-							entities[i].m_texturePath = path;
-							entities[i].SetTexture(entityShader);
+							const char* path = (const char*)payload->Data;
+							
+							Texture2D texture = Texture2D();
+							TextureData textureData = texture.Create(path, ".jpeg");
+							entities[i].textureData = textureData;
 						}
 						ImGui::EndDragDropTarget();
 					}


### PR DESCRIPTION
Add a drag and drop mechanism to add separate textures for each entity.

Note:
This does not work flawlessly yet, The order in which the textures are rendered seems to be off. Need to re-think the architecture of how textures are set-up and rendered