### PR TITLE
feat: add and render correct texture when dropped in entity

### DIFF
--- a/editor/panels/ContentBrowserPanel.cpp
+++ b/editor/panels/ContentBrowserPanel.cpp
@@ -14,13 +14,13 @@ AssetManager g_assets = AssetManager(g_assetPath);
 ContentBrowserPanel::ContentBrowserPanel()
 {
     Texture2D folderIcon = Texture2D();
-    TextureData texDataFolder = folderIcon.Create("../editor/assets/folder.png", ".png");
-    folderIcon.Load(texDataFolder);
+    folderIcon.Create("../editor/assets/folder.png", ".png");
+    folderIcon.Load();
     m_folderIcon = folderIcon.m_textureId;
     
     Texture2D fileIcon = Texture2D();
-    TextureData texDataFile = fileIcon.Create("../editor/assets/file.png", ".png");
-    fileIcon.Load(texDataFile);
+    fileIcon.Create("../editor/assets/file.png", ".png");
+    fileIcon.Load();
     m_fileIcon = fileIcon.m_textureId;
 }
 

--- a/src/Entity/Entity.hpp
+++ b/src/Entity/Entity.hpp
@@ -73,11 +73,16 @@ public:
     
     void SetTexture(Shaders shader)
     {
-        texture.Load(textureData);
-        shader.Set1iUniform("ourTexture", 0);
-        texture.Bind(GL_TEXTURE0);
+        if(!textureID)
+        {
+            texture.Unbind();
+            shader.Set1fUniform("useTexturing", 0);
+        } else {
+            texture.Bind(textureID);
+            shader.Set1fUniform("useTexturing", 1);
+        }
     }
-    
+        
     void OrbitX()
     {
         float xPos = 2.0f * sin(glfwGetTime());
@@ -125,6 +130,6 @@ public:
     bool m_orbitY = false;
     std::string m_texturePath;
     std::vector<float> m_vertices;
-    TextureData textureData;
+    unsigned int textureID = 0;
     Texture2D texture = Texture2D();
 };

--- a/src/Shaders/Object/FragmentShader.glsl
+++ b/src/Shaders/Object/FragmentShader.glsl
@@ -8,6 +8,7 @@ in vec3 fragPos;
 out vec4 FragColor;
 
 uniform sampler2D ourTexture;
+uniform bool useTexturing;
 uniform vec3 ourColor;
 uniform vec3 lightColor;
 uniform vec3 lightPos;
@@ -23,15 +24,20 @@ vec3 CalcDirLight(DirLight light, vec3 normal, vec3 fragPos);
 void main()
 {
     vec3 norm = normalize(normal);
-    vec3 result = CalcDirLight(dirLights[0], norm, fragPos) * ourColor;
+    vec3 result = CalcDirLight(dirLights[0], norm, fragPos);
     
     for(int i = 0; i < 20; i++)
     {
-        result += (CalcDirLight(dirLights[i + 1], norm, fragPos) * ourColor);
+        result += (CalcDirLight(dirLights[i + 1], norm, fragPos));
     }
     
-    FragColor = texture(ourTexture, texCoord) + vec4(result, 1.0f);
-    
+    if(useTexturing)
+    {
+        FragColor = texture(ourTexture, texCoord) * vec4(result, 1.0f);
+    } else
+    {
+        FragColor = vec4((result * ourColor), 1.0f);
+    }
 }
 
 vec3 CalcDirLight(DirLight light, vec3 normal, vec3 fragPos)

--- a/src/Textures/Texture.cpp
+++ b/src/Textures/Texture.cpp
@@ -23,7 +23,7 @@ Texture2D::~Texture2D() {
     stbi_image_free(Texture2D::m_data);
 }
 
-TextureData Texture2D::Create(const std::string& path, const std::string& extension)
+void Texture2D::Create(const std::string& path, const std::string& extension)
 {
     int width;
     int height;
@@ -37,28 +37,25 @@ TextureData Texture2D::Create(const std::string& path, const std::string& extens
     if(!data)
         std::cout << "Failed to load texture at path: " << path << std::endl;
     
-    TextureData textureData;
     textureData.width = width;
     textureData.height = height;
     textureData.colorType = colorType;
     textureData.data = data;
     
     Texture2D::m_data = data;
-    
-    return textureData;
 }
 
-void Texture2D::Load(TextureData textureData)
+void Texture2D::Load()
 {    
     glTexImage2D(GL_TEXTURE_2D, 0, textureData.colorType, textureData.width, textureData.height, 0, textureData.colorType, GL_UNSIGNED_BYTE, textureData.data);
     glGenerateMipmap(GL_TEXTURE_2D);
 }
 
 
-void Texture2D::Bind(unsigned int unit)
+void Texture2D::Bind(unsigned int textureId)
 {
-    glActiveTexture(unit);
-    glBindTexture(GL_TEXTURE_2D, Texture2D::m_textureId);
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, textureId);
 }
 
 void Texture2D::Unbind()

--- a/src/Textures/Texture.hpp
+++ b/src/Textures/Texture.hpp
@@ -14,13 +14,14 @@ class Texture2D
 public:
     Texture2D();
     ~Texture2D();
-    TextureData Create(const std::string& path, const std::string& extension);
-    void Load(TextureData textureData);
-    void Bind(unsigned int unit);
+    void Create(const std::string& path, const std::string& extension);
+    void Load();
+    void Bind(unsigned int textureId);
     void Unbind();
     
     
 public:
+    TextureData textureData;
     unsigned int m_colorType;
     unsigned int m_width;
     unsigned int m_height;

--- a/src/imgui.ini
+++ b/src/imgui.ini
@@ -9,7 +9,7 @@ Size=298,197
 Collapsed=0
 
 [Window][Sidebar]
-Pos=9,3
+Pos=8,3
 Size=216,655
 Collapsed=0
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -156,8 +156,10 @@ int main() {
 							const char* path = (const char*)payload->Data;
 							
 							Texture2D texture = Texture2D();
-							TextureData textureData = texture.Create(path, ".jpeg");
-							entities[i].textureData = textureData;
+							texture.Create(path, ".jpeg");
+							texture.Load();
+							
+							entities[i].textureID = texture.m_textureId;
 						}
 						ImGui::EndDragDropTarget();
 					}


### PR DESCRIPTION
Added a texture drag and drop system where we can pick textures from the asset manager and drop them in the entities we have created. Each entity can have it's own texture. 